### PR TITLE
PR for release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,13 @@
 
 ### 0.0.1
 - Initial Release
+
+### 1.0.0
+
+Breaking Changes:
+  - The remote object creation through ``RemoteModule`` has seen some changes.
+  - The visibility of few attributes are changed from protected to public.
+
+Add Ons:
+  - ``RpycMem`` and ``RemoteModule`` will accept callables for ``rmem_conn`` parameter
+  - Sessions are introduced through ``RpycMemSession`` class.

--- a/README.md
+++ b/README.md
@@ -27,26 +27,29 @@
 3. Share data between processes
    
    *Client 1:*
-   
+
+   Using RPyC Memory Session
+
    ```python
    from rpyc_mem.connect import RpycMemConnect
-   from rpyc_mem.client import RemoteModule, RpycMem
+   from rpyc_mem.session import RpycMemSession
    
-   rc = RpycMemConnect('localhost', 18813)
-   ro = RemoteModule(rc)
-   rm = RpycMem(rc, 'unique-key', robj_gen=lambda: ro.list([1, 2]))
+   rses = RpycMemSession('localhost', 18813)
+   rm = rses.rmem('unique-key', robj_gen=lambda: rses.rmod().list([1, 2]))
    
    print(rm)    # [1, 2]
    ```
    *Client 2:*
    
+   Using underlying RPyC Memory classes
+
    ```python
    from rpyc_mem.connect import RpycMemConnect
    from rpyc_mem.client import RemoteModule, RpycMem
    
    rc = RpycMemConnect('localhost', 18813)
-   ro = RemoteModule(rc)
-   rm = RpycMem(rc, 'unique-key', robj_gen=lambda: ro.list([1, 2, 3]))
+   rp = RemoteModule(rc)
+   rm = RpycMem(rc, 'unique-key', robj_gen=lambda: rp().list([1, 2, 3]))
    
    print(rm)    # [1, 2]
    rm.append(3)

--- a/docs/api/rpyc_mem.rst
+++ b/docs/api/rpyc_mem.rst
@@ -10,6 +10,7 @@ Subpackages
    rpyc_mem.service
    rpyc_mem.connect
    rpyc_mem.client
+   rpyc_mem.session
    rpyc_mem.utils
 
 Submodules

--- a/docs/api/rpyc_mem.session.rst
+++ b/docs/api/rpyc_mem.session.rst
@@ -1,0 +1,21 @@
+rpyc\_mem.session package
+=========================
+
+Submodules
+----------
+
+rpyc\_mem.session.rpyc\_mem\_session module
+-------------------------------------------
+
+.. automodule:: rpyc_mem.session.rpyc_mem_session
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: rpyc_mem.session
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/user_guide/mem_connect_guide.rst
+++ b/docs/user_guide/mem_connect_guide.rst
@@ -27,11 +27,11 @@ and validations. ::
 ``RPyC`` `warns <https://rpyc.readthedocs.io/en/latest/install.html#cross-interpreter-compatibility>`_ against having
 different versions for client and server; when the ``ignore_version`` is ``False``, having different versions will raise
 an exception during ``__init__``. The attributes that are not defined by ``RpycMemConnect`` are searched in the underlying
-RPyC connection object, Ex: ``rc.root`` will invoke ``getattr(self._rmem_conn, 'root')``. The ``RpycMemService``
+RPyC connection object, Ex: ``rc.root`` will invoke ``getattr(self.rpyc_conn, 'root')``. The ``RpycMemService``
 attributes can be accessed as if they were defined under ``RpycMemConnect`` namespace, Ex: ``rc.memoize == rc.root.memoize``
 
 ``RpycMemConnect`` performs some basic error recovery as configured by ``max_retry`` and ``retry_delay``. If you want to
-bypass this you can work with raw connection object ``rc._rmem_conn``. ``RpycMemConnect`` has these additional attributes:
+bypass this you can work with raw connection object ``rc.rpyc_conn``. ``RpycMemConnect`` has these additional attributes:
 
     * ``rc.setup_rmem_conn()`` - Re-setup the connection (attempt-close and open).
     * ``rc.rmem_except_handler()`` - Function decorator for handling the connection errors when working with raw
@@ -48,17 +48,17 @@ The following snippet shows their usage::
 
     # Working with raw connection object
     try:
-        rc._rmem_conn.root.rpyc_version()
+        rc.rpyc_conn.root.rpyc_version()
     except EOFError:
         rc.setup_rmem_conn()    # Re-setup the connection ([attempt] close and open)
-        print(rc._rmem_conn.root.rpyc_version())
+        print(rc.rpyc_conn.root.rpyc_version())
 
     # Recovery from connection failures
-    rc._rmem_conn.close()   # With rc.close() connection errors are no more handled
+    rc.rpyc_conn.close()   # With rc.close() connection errors are no more handled
     print(rc.rpyc_version())
 
     # Using exception handlers when working with raw connection object
-    rc._rmem_conn.close()
+    rc.rpyc_conn.close()
 
     def reconnect_hook():
         print('re-connected')
@@ -66,7 +66,7 @@ The following snippet shows their usage::
     @rc.rmem_except_handler(on_reconnect=reconnect_hook)
     def rmem_fn():
         """Function that uses rpyc connection object"""
-        print(rc._rmem_conn.root.is_memoized('not_memoized'))
+        print(rc.rpyc_conn.root.is_memoized('not_memoized'))
 
     rmem_fn()
 

--- a/docs/user_guide/mem_object_guide.rst
+++ b/docs/user_guide/mem_object_guide.rst
@@ -136,7 +136,7 @@ the cases. However, they come with few limitations. Consider the below interacti
     >>> rc = RpycMemConnect('localhost', 18813)
 
     >>> rm = RpycMem(rc, 'key', 1)
-    >>> rm = rm + 1 # rm variable is replaced by int and is garbage collected
+    >>> rm = rm + 1 # rm variable is replaced by int and the proxy object is garbage collected
     >>> print(rm)
     2
     >>> print(type(rm))

--- a/docs/user_guide/mem_object_guide.rst
+++ b/docs/user_guide/mem_object_guide.rst
@@ -18,10 +18,10 @@ and ``RpycMem`` instead of creating a new connection. ::
         print('Child Process:')
 
         rc = RpycMemConnect('localhost', 18813)
-        ro = RemoteModule(rc)
+        rp = RemoteModule(rc)
 
         # Generators allow delayed execution (dont create if mapping already exists)
-        rm = RpycMem(rc, unique_key, robj_gen=lambda: ro.list([1, 2, 3]))
+        rm = RpycMem(rc, unique_key, robj_gen=lambda: rp().list([1, 2, 3]))
         print(rm)
         rm.append(3)
 
@@ -32,9 +32,9 @@ and ``RpycMem`` instead of creating a new connection. ::
 
     # Assuming service is running on localhost:18813
     rc = RpycMemConnect('localhost', 18813)
-    ro = RemoteModule(rc)
+    rp = RemoteModule(rc)
 
-    rm = RpycMem(rc, 'unique-key', ro.list([1, 2])) # Either pass robj or robj_gen
+    rm = RpycMem(rc, 'unique-key', rp().list([1, 2])) # Either pass robj or robj_gen
 
     print(rm)
     print(len(rm))  # Python special method lookup
@@ -74,12 +74,12 @@ are shared instead of the entire class ::
 
     # Assuming service is running on localhost:18813
     rc = RpycMemConnect('localhost', 18813)
-    ro = RemoteModule(rc)
+    rp = RemoteModule(rc)
 
 
     class Shared:
-        lock = RpycMem(rc, 'lock-key', robj_gen=lambda: ro.threading.Lock())
-        obj = RpycMem(rc, 'obj-key', robj_gen=lambda: ro.list([1, 2]))
+        lock = RpycMem(rc, 'lock-key', robj_gen=lambda: rp('threading').Lock())
+        obj = RpycMem(rc, 'obj-key', robj_gen=lambda: rp().list([1, 2]))
 
         def __init__(self, title):
             self.title = title
@@ -93,7 +93,7 @@ are shared instead of the entire class ::
             with cls.lock:
                 if isinstance(cls.obj, list):
                     print(cls.obj)
-                    cls.obj.rmem_update(ro.tuple([1, 2]))
+                    cls.obj.rmem_update(rp().tuple([1, 2]))
                 else:
                     print('Oops')
 
@@ -120,18 +120,22 @@ are shared instead of the entire class ::
     Oops
     """
 
+Setting the ``multiprocessing`` start method to ``spawn`` is important on Unix based systems (On Windows and MacOs
+``spawn`` is the default start method) because this causes the file to be reimported, which will create a fresh
+RPyC connection. Otherwise two processes will talk to the server from a similar socket object (socket address), which
+will compromise the data integrity on the server side. However, one can rely on ``RpycMemSession`` and forget about
+the connections being reused in different processes. Refer to ``RPyC Memory Session`` guide for more information.
 
-The proxy objects of ``RpycMem`` class will behave like the original objects in most of the cases. However, they come
-with few limitations. The object proxying idea is inspired from the Tomer Filiba's `Python recipe <https://code.activestate.com/
-recipes/496741-object-proxying/>`_. Consider the below interactive session::
+The object proxying idea is inspired from the Tomer Filiba's `Python recipe <https://code.activestate.com/recipes/
+496741-object-proxying/>`_. The proxy objects of ``RpycMem`` class will behave like the original objects in most of
+the cases. However, they come with few limitations. Consider the below interactive session::
 
     >>> from rpyc_mem.connect import RpycMemConnect
-    >>> from rpyc_mem.client import RemoteModule, RpycMem
+    >>> from rpyc_mem.client import RpycMem
 
     >>> rc = RpycMemConnect('localhost', 18813)
-    >>> ro = RemoteModule(rc)
 
-    >>> rm = RpycMem(rc, 'key1', 1)
+    >>> rm = RpycMem(rc, 'key', 1)
     >>> rm = rm + 1 # rm variable is replaced by int and is garbage collected
     >>> print(rm)
     2

--- a/docs/user_guide/mem_service_guide.rst
+++ b/docs/user_guide/mem_service_guide.rst
@@ -31,7 +31,7 @@ kwargs used to run the server can be updated by passing ``server_kwargs`` argume
 
 
 Refer to `RPyC documentation <https://rpyc.readthedocs.io/en/latest/api/utils_server.html>`_ for the servers that come
-inbuilt. If the port is left out, a random port is assigned which can be accessed through ``self._server_obj.port``
+inbuilt. If the port is left out, a random port is assigned which can be accessed through ``self.server_obj.port``
 (this is available only after the service is ran).
 
 In the background, ``RpycMemService`` maintains a mapping between the key and the object in a dict. All management

--- a/docs/user_guide/mem_session_guide.rst
+++ b/docs/user_guide/mem_session_guide.rst
@@ -1,0 +1,77 @@
+RPyC Memory Session
+-------------------
+
+Juggling around the ``RpycMemConnect`` object across ``RemoteModule`` and ``RpycMem`` can be redundant. ``RpycMemSession``
+brings all of them under one hood and re-purposes the connection object for different operations. ``RpycMemSession`` also
+solves the problem of two processes using a similar ``RPyC`` connection object; this is documented at detail in this `issue
+<https://github.com/tomerfiliba-org/rpyc/issues/482>`_. In breif, when a process forks a child, child gets the memory snapshot
+of the parent, which includes the underlying socket object of rpyc connection. When both parent and child try to send data to
+the server from same socket address, it corrupts the request message structure as defined by the rpyc protocol. To solve this,
+``RpycMemSession`` passes callable for ``rmem_conn`` parameter of ``RemoteModule`` and ``RpycMem``. This callable acts as
+generator of ``rmem_conn`` object. Every time a connection object is needed the callable is invoked. Now ``RpycMemSession``
+keeps track of the processes and whenever a process change is detected a fresh ``rmem_conn`` object is returned. Consider the
+same example as laid out in ``RPyC Memory`` guide but using ``RpycMemSession``::
+
+    import multiprocessing
+    from multiprocessing import Process
+
+    from rpyc_mem.session import RpycMemSession
+
+    """
+    Assuming service is running on localhost:18813
+
+    Defaults:
+    max_retry=4 # Retry is at session level. In specific at session level for each connection object.
+    retry_delay=3
+    ignore_version=False
+    process_safe=True # Make session to return new connection object upon process change.
+    """
+    rses = RpycMemSession('localhost', 18813)
+
+
+    class Shared:
+        lock = rses.rmem('lock-key', robj_gen=lambda: rses.rmod('threading').Lock())
+        obj = rses.rmem('obj-key', robj_gen=lambda: rses.rmod().list([1, 2]))
+
+        def __init__(self, title):
+            self.title = title
+
+        def describe(self):
+            with self.lock:
+                print('%s: %s' % (self.title, self.obj))
+
+        @classmethod
+        def run(cls):
+            with cls.lock:
+                if isinstance(cls.obj, list):
+                    print(cls.obj)
+                    cls.obj.rmem_update(rses.rmod().tuple([1, 2]))
+                else:
+                    print('Oops')
+
+
+    if __name__ == '__main__':
+        # multiprocessing.set_start_method('spawn')
+
+        proc1 = Process(target=Shared.run)
+        proc2 = Process(target=Shared.run)
+        proc3 = Process(target=Shared('Cool-Class').describe)
+
+        proc1.start()
+        proc2.start()
+        proc3.start()
+
+        proc1.join()
+        proc2.join()
+        proc3.join()
+
+    """
+    Output (varied):
+    Cool-Class: [1, 2]
+    [1, 2]
+    Oops
+    """
+
+
+Note the ``set_start_method`` being commented out (makes difference only on Unix based systems). ``RemoteModule`` of the session
+can be accessed through ``rmod``; It is a singleton object.

--- a/docs/user_guide/remote_module_guide.rst
+++ b/docs/user_guide/remote_module_guide.rst
@@ -12,9 +12,9 @@ object for creating remote objects. ::
     # Assuming service running on localhost:18813
     rc = RpycMemConnect('localhost', 18813)
 
-    ro = RemoteModule(rc)
+    rp = RemoteModule(rc)
 
-    rlist = ro.list([1, 2])
+    rlist = rp().list([1, 2])
     for i in rlist:
         print(i)
 
@@ -22,11 +22,11 @@ object for creating remote objects. ::
     print(type(rlist) == type([1]))
     print(type(rlist))
 
-    rlock = ro.threading.Lock()
+    rlock = rp('threading').Lock()
     rlock.acquire()
-
     print(rlock.locked())
     rlock.release()
+
     with rlock:
         print('synchronized operation')
 
@@ -42,6 +42,5 @@ object for creating remote objects. ::
     """
 
 
-As part of the module resolution, ``RemoteModule`` first searches in the ``builtins`` of remote (``ro.list == ro.builtins.
-list``), if not resolved then tries to (remote) import the package. Remote generators are simply the callables that return
-remote objects created with ``RemoteModule``.
+``RemoteModule`` supports `importlib.import_module <https://docs.python.org/3/library/importlib.html#importlib.import_module>`_ 
+style imports. When ``module`` parameter is not passed, ``builtins`` is assumed by default.

--- a/docs/user_guide/user_guide.rst
+++ b/docs/user_guide/user_guide.rst
@@ -8,3 +8,4 @@ User Guide
    mem_connect_guide
    remote_module_guide
    mem_object_guide
+   mem_session_guide

--- a/rpyc_mem/_version.py
+++ b/rpyc_mem/_version.py
@@ -1,3 +1,3 @@
 """Version Information."""
 
-__version__ = '0.0.1'
+__version__ = '1.0.0'

--- a/rpyc_mem/client/remote_module.py
+++ b/rpyc_mem/client/remote_module.py
@@ -7,26 +7,24 @@ class RemoteModule:
 
     :param rpyc_mem.connect.RpycMemConnect rmem_conn: Rpyc memory connection
 
-    .. automethod:: __getattr__
+    .. automethod:: __call__
     """
 
     def __init__(self, rmem_conn):
         """Initialize RemoteModule with rpyc memory connection"""
         self._rmem_conn = rmem_conn
 
-    def __getattr__(self, name):
+    def __call__(self, module=None, package=None):
         """
-        Return ``builtins``/``modules`` of rpyc memory service hosts. Search in remote
-        ``builtins`` before attempting to import ``name`` module.
+        Return the ``modules`` of rpyc memory service hosts. If module is ``None`` assume ``builtins``.
 
-        :param str name: Name of the remote builtins/module
+        :param str module: The module to import in absolute or relative terms (Ex: pkg.mod, ..mod).
+         Defaults to ``builtins``.
+        :param str package: The package which acts as a base for resolving the module (should be set
+         when relative imports are used)
         :return:
         """
-        # Search in remote builtins
-        try:
-            return getattr(self._rmem_conn.remote_import('builtins'), name)
-        except AttributeError:
-            pass
+        if not module:
+            module = 'builtins'
 
-        # Import 'name' module from rmem host
-        return self._rmem_conn.remote_import(name)
+        return self._rmem_conn.remote_import(module, package)

--- a/rpyc_mem/client/remote_module.py
+++ b/rpyc_mem/client/remote_module.py
@@ -28,9 +28,9 @@ class RemoteModule:
 
         return self._rmem_conn
 
-    def __call__(self, module=None, package=None):
+    def __call__(self, module='builtins', package=None):
         """
-        Return the ``modules`` of rpyc memory service hosts. If module is ``None`` assume ``builtins``.
+        Return ``modules`` of rpyc memory service hosts.
 
         :param str module: The module to import in absolute or relative terms (Ex: pkg.mod, ..mod).
          Defaults to ``builtins``.
@@ -39,7 +39,4 @@ class RemoteModule:
 
         :return:
         """
-        if not module:
-            module = 'builtins'
-
         return self.rmem_conn.remote_import(module, package)

--- a/rpyc_mem/client/remote_module.py
+++ b/rpyc_mem/client/remote_module.py
@@ -5,7 +5,8 @@ class RemoteModule:
     """
     Expose remote modules to create remote python objects
 
-    :param rpyc_mem.connect.RpycMemConnect rmem_conn: Rpyc memory connection
+    :param Union[rpyc_mem.connect.RpycMemConnect, typing.Callable] rmem_conn: Rpyc memory connection
+     or a callable that returns Rpyc memory connection
 
     .. automethod:: __call__
     """
@@ -13,6 +14,19 @@ class RemoteModule:
     def __init__(self, rmem_conn):
         """Initialize RemoteModule with rpyc memory connection"""
         self._rmem_conn = rmem_conn
+
+    @property
+    def rmem_conn(self):
+        """
+        Return the Rpyc memory connection from ``_rmem_conn`` object. If ``_rmem_conn`` is
+        callable return the result of ``_rmem_conn`` invocation else ``_rmem_conn``.
+
+        :return:
+        """
+        if callable(self._rmem_conn):
+            return self._rmem_conn()
+
+        return self._rmem_conn
 
     def __call__(self, module=None, package=None):
         """
@@ -22,9 +36,10 @@ class RemoteModule:
          Defaults to ``builtins``.
         :param str package: The package which acts as a base for resolving the module (should be set
          when relative imports are used)
+
         :return:
         """
         if not module:
             module = 'builtins'
 
-        return self._rmem_conn.remote_import(module, package)
+        return self.rmem_conn.remote_import(module, package)

--- a/rpyc_mem/client/rpyc_mem_object.py
+++ b/rpyc_mem/client/rpyc_mem_object.py
@@ -58,7 +58,10 @@ class RpycMem:
 
         :return:
         """
-        return self.rmem_get()
+        try:
+            return self.rmem_get()
+        except RpycMemSvcError:
+            raise RpycMemError('Can not recover remote object from RPyC memory service')
 
     def rmem_memoize(self, robj=_DEFAULT, robj_gen=_DEFAULT):
         """
@@ -85,10 +88,7 @@ class RpycMem:
 
         :return:
         """
-        try:
-            return self.rmem_conn.get(self.unique_key)
-        except RpycMemSvcError:
-            raise RpycMemError('Can not recover remote object from RPyC memory service')
+        return self.rmem_conn.get(self.unique_key)
 
     def rmem_update(self, robj=_DEFAULT, robj_gen=_DEFAULT):
         """

--- a/rpyc_mem/client/rpyc_mem_object.py
+++ b/rpyc_mem/client/rpyc_mem_object.py
@@ -8,47 +8,55 @@ from rpyc_mem.utils.object_proxy import proxify
 rpyc.core.vinegar._generic_exceptions_cache['rpyc_mem.errors.RpycMemSvcError'] = RpycMemSvcError  # noqa
 
 
-@proxify(real_attr='_real_obj', local_attrs=[
-    '_real_obj', '_DEFAULT', '_rmem_conn', '_unique_key', '_robj', '_robj_gen',
+@proxify(real_attr='real_obj', local_attrs=[
+    'real_obj', '_DEFAULT', '_rmem_conn', 'rmem_conn', 'unique_key', 'robj', 'robj_gen',
     'rmem_memoize', 'rmem_get', 'rmem_update', 'rmem_delete', '_validate_obj_sources'
 ])
 class RpycMem:
     """
     Proxy class for python objects residing on RPyC memory service hosts
 
-    :param rpyc_mem.connect.RpycMemConnect rmem_conn: Rpyc memory connection on which the remote
-     object should be synced
+    :param Union[rpyc_mem.connect.RpycMemConnect, typing.Callable] rmem_conn: Rpyc memory connection (or
+     connection callable) on which the remote object should be synced
     :param unique_key: The unique-key for syncing the remote object with Rpyc memory service
     :param typing.Any robj: The remote object to use for memoization (One among robj, robj_gen
      should be passed).
     :param typing.Callable robj_gen: The remote object generator to use for memoization (One among robj,
      robj_gen should be passed).
-
-     .. autoproperty:: _real_obj
     """
     _DEFAULT = object()
 
     def __init__(self, rmem_conn, unique_key, robj=_DEFAULT, robj_gen=_DEFAULT):
         """Initialize Rpyc(shared) memory object"""
         self._rmem_conn = rmem_conn
-        self._unique_key = unique_key
-        self._robj = robj
-        self._robj_gen = robj_gen
+        self.unique_key = unique_key
+        self.robj = robj
+        self.robj_gen = robj_gen    # noqa
 
         # Memoize remote object
         self.rmem_memoize(robj, robj_gen)   # noqa
 
     @property
-    def _real_obj(self):
+    def rmem_conn(self):
         """
-        The remote object property.
+        Return the Rpyc memory connection from ``_rmem_conn`` object. If ``_rmem_conn`` is callable
+        return the result of ``_rmem_conn`` invocation else ``_rmem_conn``.
 
         :return:
         """
-        try:
-            return self._rmem_conn.get(self._unique_key)
-        except RpycMemSvcError:
-            raise RpycMemError('Can not recover remote object from RPyC memory service')
+        if callable(self._rmem_conn):
+            return self._rmem_conn()
+
+        return self._rmem_conn
+
+    @property
+    def real_obj(self):
+        """
+        Property wrapper around rmem_get()
+
+        :return:
+        """
+        return self.rmem_get()
 
     def rmem_memoize(self, robj=_DEFAULT, robj_gen=_DEFAULT):
         """
@@ -64,17 +72,20 @@ class RpycMem:
             raise RpycMemError('Either remote object or remote object generator should be passed')
 
         if robj is not self._DEFAULT:
-            return self._rmem_conn.memoize(self._unique_key, robj=robj)
+            return self.rmem_conn.memoize(self.unique_key, robj=robj)
         else:
-            return self._rmem_conn.memoize(self._unique_key, robj_gen=robj_gen)
+            return self.rmem_conn.memoize(self.unique_key, robj_gen=robj_gen)
 
     def rmem_get(self):
         """
-        Get the remote object against the unique-key
+        Get the live remote object against the unique-key.
 
         :return:
         """
-        return self._rmem_conn.get(self._unique_key)
+        try:
+            return self.rmem_conn.get(self.unique_key)
+        except RpycMemSvcError:
+            raise RpycMemError('Can not recover remote object from RPyC memory service')
 
     def rmem_update(self, robj=_DEFAULT, robj_gen=_DEFAULT):
         """
@@ -90,9 +101,9 @@ class RpycMem:
             raise RpycMemError('Either remote object or remote object generator should be passed')
 
         if robj is not self._DEFAULT:
-            return self._rmem_conn.update(self._unique_key, robj=robj)
+            return self.rmem_conn.update(self.unique_key, robj=robj)
         else:
-            return self._rmem_conn.update(self._unique_key, robj_gen=robj_gen)
+            return self.rmem_conn.update(self.unique_key, robj_gen=robj_gen)
 
     def rmem_delete(self):
         """
@@ -100,7 +111,7 @@ class RpycMem:
 
         :return:
         """
-        self._rmem_conn.delete(self._unique_key)
+        self.rmem_conn.delete(self.unique_key)
 
     @classmethod
     def _validate_obj_sources(cls, robj, robj_gen):

--- a/rpyc_mem/client/rpyc_mem_object.py
+++ b/rpyc_mem/client/rpyc_mem_object.py
@@ -16,13 +16,15 @@ class RpycMem:
     """
     Proxy class for python objects residing on RPyC memory service hosts
 
-    :param Union[rpyc_mem.connect.RpycMemConnect, typing.Callable] rmem_conn: Rpyc memory connection (or
-     connection callable) on which the remote object should be synced
-    :param unique_key: The unique-key for syncing the remote object with Rpyc memory service
-    :param typing.Any robj: The remote object to use for memoization (One among robj, robj_gen
-     should be passed).
-    :param typing.Callable robj_gen: The remote object generator to use for memoization (One among robj,
+    :param Union[rpyc_mem.connect.RpycMemConnect, typing.Callable] rmem_conn: Rpyc memory
+     connection or a callable that returns Rpyc memory connection on which the remote object
+     should be synced
+    :param typing.Hashable unique_key: The unique-key for syncing the remote object with
+     Rpyc memory service
+    :param typing.Any robj: The remote object to use for memoization (One among robj,
      robj_gen should be passed).
+    :param typing.Callable robj_gen: The remote object generator to use for memoization
+     (One among robj, robj_gen should be passed).
     """
     _DEFAULT = object()
 
@@ -39,8 +41,8 @@ class RpycMem:
     @property
     def rmem_conn(self):
         """
-        Return the Rpyc memory connection from ``_rmem_conn`` object. If ``_rmem_conn`` is callable
-        return the result of ``_rmem_conn`` invocation else ``_rmem_conn``.
+        Return the Rpyc memory connection from ``_rmem_conn`` object. If ``_rmem_conn`` is
+        callable return the result of ``_rmem_conn`` invocation else ``_rmem_conn``.
 
         :return:
         """
@@ -62,10 +64,11 @@ class RpycMem:
         """
         Memoize the remote object against the unique_key
 
-        :param typing.Any robj: The remote object to use for memoization (One among robj, robj_gen should be
-         passed).
-        :param typing.Callable robj_gen: The remote object generator to use for memoization (One among robj,
+        :param typing.Any robj: The remote object to use for memoization (One among robj,
          robj_gen should be passed).
+        :param typing.Callable robj_gen: The remote object generator to use for memoization
+         (One among robj, robj_gen should be passed).
+
         :return:
         """
         if not self._validate_obj_sources(robj, robj_gen):
@@ -91,10 +94,11 @@ class RpycMem:
         """
         Update remote object on RPyC memory service hosts
 
-        :param typing.Any robj: The remote object to use for update (One among robj, robj_gen should be
-         passed).
-        :param typing.Callable robj_gen: The remote object generator to use for update (One among robj,
-         robj_gen should be passed).
+        :param typing.Any robj: The remote object to use for update (One among robj, robj_gen
+         should be passed).
+        :param typing.Callable robj_gen: The remote object generator to use for update (One
+         among robj, robj_gen should be passed).
+
         :return:
         """
         if not self._validate_obj_sources(robj, robj_gen):
@@ -120,6 +124,7 @@ class RpycMem:
 
         :param typing.Any robj: Remote object
         :param typing.Callable robj_gen: Remote object generator
+
         :return:
         """
         if (robj is cls._DEFAULT and robj_gen is cls._DEFAULT) or \

--- a/rpyc_mem/session/__init__.py
+++ b/rpyc_mem/session/__init__.py
@@ -1,0 +1,1 @@
+from .rpyc_mem_session import RpycMemSession

--- a/rpyc_mem/session/rpyc_mem_session.py
+++ b/rpyc_mem/session/rpyc_mem_session.py
@@ -23,8 +23,8 @@ class RpycMemSession:
     :param int max_retry: Number of times to retry upon connection failure (at session level).
     :param int retry_delay: Retry delay in seconds between each re-connect attempt
     :param bool ignore_version: Do not validate the server RPyC version with the client
-    :param bool process_safe: Create a new Rpyc Mem connection when the session object is
-     accessed by the process who is not the actual creator of the session.
+    :param bool process_safe: Create a new Rpyc Mem connection when the objects created by the
+     session are accessed by the process who is not the actual creator of the session.
     """
     _DEFAULT = object()
 

--- a/rpyc_mem/session/rpyc_mem_session.py
+++ b/rpyc_mem/session/rpyc_mem_session.py
@@ -15,8 +15,8 @@ class RpycMemSession:
     (underlying socket object is similar) when used in different processes may result in race
     conditions (Refer https://github.com/tomerfiliba-org/rpyc/issues/482). ``RpycMemSession``
     can deal with it by keeping track of processes. ``RpycMemSession`` has functionality for
-    creating ``RemoteModule`` object (singleton) and ``RpycMem`` objects. The underlying Rpyc
-    Mem connection can be retrieved through ``rmem_conn`` property.
+    creating ``RemoteModule`` object (singleton, accessible via ``rmod``) and ``RpycMem`` objects.
+    The underlying Rpyc Mem connection can be retrieved through ``rmem_conn`` property.
 
     :param str hostname: RPyC memory service hostname
     :param int port: RPyC memory service port
@@ -39,8 +39,9 @@ class RpycMemSession:
         self.process_safe = process_safe
 
         self._rmem_conn = None
-        self._rmod = None
         self._process = multiprocessing.current_process().pid
+
+        self.rmod = RemoteModule(self._callable_rmem_conn)
 
     @property
     def rmem_conn(self):
@@ -72,18 +73,6 @@ class RpycMemSession:
     def _callable_rmem_conn(self):
         """Callable wrapper around rmem_conn"""
         return self.rmem_conn
-
-    @property
-    def rmod(self):
-        """
-        Return RemoteModule (singleton) which uses session's rpyc memory connection.
-
-        :return:
-        """
-        if not self._rmod:
-            self._rmod = RemoteModule(self._callable_rmem_conn)
-
-        return self._rmod
 
     def rmem(self, unique_key, robj=_DEFAULT, robj_gen=_DEFAULT):
         """

--- a/rpyc_mem/session/rpyc_mem_session.py
+++ b/rpyc_mem/session/rpyc_mem_session.py
@@ -1,0 +1,128 @@
+"""RPyC Memory Session"""
+
+import multiprocessing
+
+from rpyc_mem.client import RemoteModule, RpycMem
+from rpyc_mem.connect import RpycMemConnect
+from rpyc_mem.errors import RpycMemError
+
+
+class RpycMemSession:
+    """
+    ``RpycMemSession`` brings ``RpycMemConnect``, ``RemoteModule`` and ``RpycMem`` under one
+    hood while enabling to create/manage remote objects efficiently. ``RpycMemSession`` will
+    repurpose the connection object for different operations. A similar raw RPyC connection
+    (underlying socket object is similar) when used in different processes may result in race
+    conditions (Refer https://github.com/tomerfiliba-org/rpyc/issues/482). ``RpycMemSession``
+    can deal with it by keeping track of processes. ``RpycMemSession`` has functionality for
+    creating ``RemoteModule`` object (singleton) and ``RpycMem`` objects. The underlying Rpyc
+    Mem connection can be retrieved through ``rmem_conn`` property.
+
+    :param str hostname: RPyC memory service hostname
+    :param int port: RPyC memory service port
+    :param int max_retry: Number of times to retry upon connection failure (at session level).
+    :param int retry_delay: Retry delay in seconds between each re-connect attempt
+    :param bool ignore_version: Do not validate the server RPyC version with the client
+    :param bool process_safe: Create a new Rpyc Mem connection when the session object is
+     accessed by the process who is not the actual creator of the session.
+    """
+    _DEFAULT = object()
+
+    def __init__(self, hostname, port, max_retry=4, retry_delay=3, ignore_version=False,
+                 process_safe=True):
+        """Initialize RpycMemSession"""
+        self.hostname = hostname
+        self.port = port
+        self.max_retry = max_retry
+        self.retry_delay = retry_delay
+        self.ignore_version = ignore_version
+        self.process_safe = process_safe
+
+        self._rmem_conn = None
+        self._rmod = None
+        self._process = multiprocessing.current_process().pid
+
+    @property
+    def rmem_conn(self):
+        """
+        Return RpycMemConnection in a process-safe way (if set to True)
+
+        :return rpyc_mem.connect.RpycMemConnect:
+        """
+        init_conn = False
+        # Check for process changes since the session creation
+        if self.process_safe:
+            curr_proc = multiprocessing.current_process().pid
+            if curr_proc != self._process:
+                self._process = curr_proc
+                init_conn = True
+
+        # Handle first time connection setup
+        if not self._rmem_conn:
+            init_conn = True
+
+        if init_conn:
+            self._rmem_conn = RpycMemConnect(
+                hostname=self.hostname, port=self.port, max_retry=self.max_retry,
+                retry_delay=self.retry_delay, ignore_version=self.ignore_version
+            )
+
+        return self._rmem_conn
+
+    def _callable_rmem_conn(self):
+        """Callable wrapper around rmem_conn"""
+        return self.rmem_conn
+
+    @property
+    def rmod(self):
+        """
+        Return RemoteModule (singleton) which uses session's rpyc memory connection.
+
+        :return:
+        """
+        if not self._rmod:
+            self._rmod = RemoteModule(self._callable_rmem_conn)
+
+        return self._rmod
+
+    def rmem(self, unique_key, robj=_DEFAULT, robj_gen=_DEFAULT):
+        """
+        Create RpycMem object against the unique_key while using robj, robj_gen through
+        session's Rpyc memory connection
+
+        :param typing.Hashable unique_key: The unique-key for syncing the remote object with
+         Rpyc memory service.
+        :param typing.Any robj: The remote object to use for memoization (One among robj,
+         robj_gen should be passed).
+        :param typing.Callable robj_gen: The remote object generator to use for memoization
+         (One among robj, robj_gen should be passed).
+
+        :return:
+        """
+        if not self._validate_obj_sources(robj, robj_gen):
+            raise RpycMemError('Either remote object or remote object generator should be passed')
+
+        if robj is not self._DEFAULT:
+            return RpycMem(
+                rmem_conn=self._callable_rmem_conn, unique_key=unique_key, robj=robj
+            )
+        else:
+            return RpycMem(
+                rmem_conn=self._callable_rmem_conn, unique_key=unique_key, robj_gen=robj_gen
+            )
+
+    @classmethod
+    def _validate_obj_sources(cls, robj, robj_gen):
+        """
+        Validate object sources. Return False if both robj, robj_gen are set/not-set else True
+
+        :param typing.Any robj: Remote object
+        :param typing.Callable robj_gen: Remote object generator
+
+        :return:
+        """
+        if (robj is cls._DEFAULT and robj_gen is cls._DEFAULT) or \
+                (robj is not cls._DEFAULT and robj_gen is not cls._DEFAULT):
+            return False
+
+        return True


### PR DESCRIPTION
Breaking Changes:
  - The remote object creation through ``RemoteModule`` has seen some changes.
  - The visibility of few attributes are changed from protected to public.

Add Ons:
  - ``RpycMem`` and ``RemoteModule`` will accept callables for ``rmem_conn`` parameter
  - Sessions are introduced through ``RpycMemSession`` class.